### PR TITLE
Reuse old changes

### DIFF
--- a/ScreenManager.lua
+++ b/ScreenManager.lua
@@ -49,12 +49,27 @@ You will have to add a new one to your screen list or use one of the existing sc
 local stack
 local screens
 
+local old_changes = setmetatable( {}, { __mode = 'v' } )
 local changes = {}
 local height = 0 --Stack height
 
 -- ------------------------------------------------
 -- Private Functions
 -- ------------------------------------------------
+
+---
+-- Cleans a table and fills it with the passed arguments
+--
+local function refill( t, ... )
+    local n = select( '#', ... )
+
+    for i=1, math.max( t.n, n ) do
+        t[i] = select( i, ... )
+    end
+
+    t.n = n
+    return t
+end
 
 ---
 -- Close and remove all screens from the stack.
@@ -138,6 +153,8 @@ function ScreenManager.performChanges()
         elseif change.action == 'push' then
             push( change.screen, change.args )
         end
+
+        old_changes[#old_changes + 1] = change
     end
 end
 
@@ -179,7 +196,15 @@ end
 function ScreenManager.switch( screen, ... )
     validateScreen( screen )
     height = 1
-    changes[#changes + 1] = { action = 'switch', screen = screen, args = { ... } }
+
+    local change = old_changes[#old_changes] or {}
+    old_changes[#old_changes] = nil
+
+    change.action = 'switch'
+    change.screen = screen
+    change.args = refill( change.args or { n = 0 }, ... )
+
+    changes[#changes + 1] = change
 end
 
 ---
@@ -195,7 +220,15 @@ end
 function ScreenManager.push( screen, ... )
     validateScreen( screen )
     height = height + 1
-    changes[#changes + 1] = { action = 'push', screen = screen, args = { ... } }
+
+    local change = old_changes[#old_changes] or {}
+    old_changes[#old_changes] = nil
+
+    change.action = 'push'
+    change.screen = screen
+    change.args = refill( change.args or { n = 0 }, ... )
+
+    changes[#changes + 1] = change
 end
 
 ---
@@ -214,7 +247,13 @@ end
 function ScreenManager.pop()
     if height > 1 then
         height = height - 1
-        changes[#changes + 1] = { action = 'pop' }
+
+        local change = old_changes[#old_changes] or {}
+        old_changes[#old_changes] = nil
+
+        change.action = 'pop'
+
+        changes[#changes + 1] = change
     else
         error("Can't close the last screen. Use switch() to clear the screen manager and add a new screen.", 2)
     end

--- a/ScreenManager.lua
+++ b/ScreenManager.lua
@@ -126,11 +126,10 @@ end
 -- @see push, pop, switch
 --
 function ScreenManager.performChanges()
-    if #changes == 0 then
-        return
-    end
+    for i=1, #changes do
+        local change = changes[i]
+        changes[i] = nil
 
-    for _, change in ipairs( changes ) do
         if change.action == 'pop' then
             pop()
         elseif change.action == 'switch' then
@@ -140,8 +139,6 @@ function ScreenManager.performChanges()
             push( change.screen, change.args )
         end
     end
-
-    changes = {}
 end
 
 ---


### PR DESCRIPTION
`change` are tables pushed to the `changes` table, it's best to reuse them instead of allocating new tables.

To do this, there is an `old_changes` table, which stores the changes that have already been performed, in a weak way (this means that the garbage collector can still collect this changes if needed)

The this old changes are then refilled with the new information of the new `change` and pushed to `changes` again.